### PR TITLE
Add buildAndroidApkDir config

### DIFF
--- a/libs/android.js
+++ b/libs/android.js
@@ -32,8 +32,8 @@ class Android {
      * @param {String} param0.appName - Label of release APK created after build process
      * @param {Boolean} param0.verbose - The logger prints every process message only if it's true
      */
-    signAPK({androidProjectPath, keystore : {path : keystorePath, alias : keystoreAlias, password : keystorePassword}, appName = 'android', verbose}) {
-        const buildApkPath = path.join(androidProjectPath, './build/outputs/apk');
+    signAPK({androidProjectPath, keystore : {path : keystorePath, alias : keystoreAlias, password : keystorePassword}, buildAndroidApkDir, appName = 'android', verbose}) {
+        const buildApkPath = path.join(androidProjectPath, buildAndroidApkDir);
         process.chdir(buildApkPath);
         const cmdAndroidSignAPK = `jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore '${keystorePath}' -storepass '${keystorePassword}' '${appName}-release-unsigned.apk' '${keystoreAlias}'`;
         let err = shell.exec(cmdAndroidSignAPK, {silent : !verbose}).stderr;
@@ -55,8 +55,8 @@ class Android {
      * @param {String} param0.apkFilePath - Destination path of aligned APK
      * @param {Boolean} param0.verbose - The logger prints every process message only if it's true
      */
-    alignAPK({androidProjectPath, appName = 'android', apkFilePath, verbose}) {
-        const buildApkPath = path.join(androidProjectPath, './build/outputs/apk');
+    alignAPK({androidProjectPath, appName = 'android', apkFilePath, buildAndroidApkDir, verbose}) {
+        const buildApkPath = path.join(androidProjectPath, buildAndroidApkDir);
         process.chdir(buildApkPath);
         const cmdAndroidAlignAPK = `zipalign -vf 4 '${appName}-release-unsigned.apk' '${apkFilePath}'`;
         let err = shell.exec(cmdAndroidAlignAPK, {silent : !verbose}).stderr;

--- a/libs/bin/distribute-cordova.js
+++ b/libs/bin/distribute-cordova.js
@@ -239,6 +239,7 @@ const startDistribution = () => {
                 versionCode  : config.android.versionCode,
 
                 cordovaPath         : config.cordova.path,
+                buildAndroidApkDir  : config.cordova.buildAndroidApkDir,
                 buildAndroidCommand : config.cordova.buildAndroidCommand,
 
                 apkFilePath : config.android.apkFilePath,

--- a/libs/config.js
+++ b/libs/config.js
@@ -48,7 +48,8 @@ class Config {
             configPath          : '',
             rootPath            : '',
             buildIosCommand     : 'cordova build ios',
-            buildAndroidCommand : 'cordova build --release android'
+            buildAndroidCommand : 'cordova build --release android',
+            buildAndroidApkDir  : './build/outputs/apk/release'
         };
 
         this.buildsDir = 'builds/';

--- a/libs/cordova.js
+++ b/libs/cordova.js
@@ -121,14 +121,14 @@ const Cordova = {
     /**
      * Exec all task to prepare and build the Android platform
      */
-    distributeAndroid({launcherName, id, versionCode, cordovaPath, buildAndroidCommand = 'cordova build --release android', apkFilePath, keystore, verbose = false}) {
+    distributeAndroid({launcherName, id, versionCode, cordovaPath, buildAndroidApkDir, buildAndroidCommand = 'cordova build --release android', apkFilePath, keystore, verbose = false}) {
         this.setId({cordovaPath, id});
         this.setAndroidVersionCode({cordovaPath, versionCode});
         this.setLauncherName({cordovaPath, launcherName});
         this.buildAndroid({buildAndroidCommand, cordovaPath, verbose});
         const androidProjectPath = path.join(cordovaPath, './platforms/android');
-        android.signAPK({androidProjectPath, keystore, verbose});
-        android.alignAPK({androidProjectPath, apkFilePath, verbose});
+        android.signAPK({androidProjectPath, keystore, buildAndroidApkDir, verbose});
+        android.alignAPK({androidProjectPath, apkFilePath, buildAndroidApkDir, verbose});
     },
 
     /**


### PR DESCRIPTION
Aggiunta la possibilità di configurare la cartella in cui cordova genera l'apk android. 

Di seguito le versioni che hanno causato la necessità:

- piattaforma cordova-android: 6.4.0
- plugin cordova-plugin-crosswalk-webview: 2.4.0